### PR TITLE
Add validation block to TextField

### DIFF
--- a/Examples/Programmatic/TextField/TextField/ViewController.swift
+++ b/Examples/Programmatic/TextField/TextField/ViewController.swift
@@ -20,75 +20,86 @@ import UIKit
 import MaterialKit
 
 class ViewController: UIViewController, TextFieldDelegate {
-	private lazy var nameField: TextField = TextField()
-	private lazy var emailField: TextField = TextField()
-	
-	override func viewDidLoad() {
-		super.viewDidLoad()
-		prepareView()
-		
-		prepareNameField()
-		prepareEmailField()
-	}
-	
-	/**
-	:name:	prepareView
-	*/
-	private func prepareView() {
-		view.backgroundColor = MaterialColor.white
-	}
-	
-	/**
-	:name:	prepareNameField
-	:description:	A preparation helper for nameField.
-	*/
-	private func prepareNameField() {
-		nameField.delegate = self
-		nameField.frame = CGRectMake(57, 100, 300, 24)
-		nameField.placeholder = "First Name"
-		nameField.font = RobotoFont.regularWithSize(20)
-		nameField.textColor = MaterialColor.black
-		nameField.titleLabel = UILabel()
-		nameField.titleLabel!.font = RobotoFont.mediumWithSize(12)
-		nameField.titleLabelNormalColor = MaterialColor.grey.lighten2
-		nameField.titleLabelHighlightedColor = MaterialColor.blue.accent3
-		nameField.clearButtonMode = .WhileEditing
-		view.addSubview(nameField)
-	}
-	
-	/**
-	:name:	prepareEmailField
-	:description:	A preparation helper for emailField.
-	*/
-	private func prepareEmailField() {
-		emailField.delegate = self
-		emailField.frame = CGRectMake(57, 200, 300, 24)
-		emailField.placeholder = "Email"
-		emailField.font = RobotoFont.regularWithSize(20)
-		emailField.textColor = MaterialColor.black
-		emailField.titleLabel = UILabel()
-		emailField.titleLabel!.font = RobotoFont.mediumWithSize(12)
-		emailField.titleLabelNormalColor = MaterialColor.grey.lighten2
-		emailField.titleLabelHighlightedColor = MaterialColor.blue.accent3
-		emailField.clearButtonMode = .WhileEditing
-		emailField.detailLabel = UILabel()
-		emailField.detailLabel!.text = "Email is incorrect."
-		emailField.detailLabel!.font = RobotoFont.mediumWithSize(12)
-		emailField.detailLabelHighlightedColor = MaterialColor.red.accent3
-		view.addSubview(emailField)
-	}
-	
-	/**
-	:name:	textFieldShouldReturn
-	:description: This is called when the user presses the Return
-				  key on the keyboard.
-	*/
-	func textFieldShouldReturn(textField: UITextField) -> Bool {
-		textField.resignFirstResponder()
-		if textField == emailField {
-			(textField as! TextField).detailLabelHidden = false
-		}
-		return false
-	}
-	
+    private lazy var nameField: TextField = TextField()
+    private lazy var emailField: TextField = TextField()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        prepareView()
+        
+        prepareNameField()
+        prepareEmailField()
+    }
+    
+    /**
+     :name:	prepareView
+     */
+    private func prepareView() {
+        view.backgroundColor = MaterialColor.white
+    }
+    
+    /**
+     :name:	prepareNameField
+     :description:	A preparation helper for nameField.
+     */
+    private func prepareNameField() {
+        nameField.delegate = self
+        nameField.frame = CGRectMake(57, 100, 300, 24)
+        nameField.placeholder = "First Name"
+        nameField.font = RobotoFont.regularWithSize(20)
+        nameField.textColor = MaterialColor.black
+        nameField.titleLabel = UILabel()
+        nameField.titleLabel!.font = RobotoFont.mediumWithSize(12)
+        nameField.titleLabelNormalColor = MaterialColor.grey.lighten2
+        nameField.titleLabelHighlightedColor = MaterialColor.blue.accent3
+        nameField.clearButtonMode = .WhileEditing
+        view.addSubview(nameField)
+    }
+    
+    /**
+     :name:	prepareEmailField
+     :description:	A preparation helper for emailField.
+     */
+    private func prepareEmailField() {
+        emailField.delegate = self
+        emailField.frame = CGRectMake(57, 200, 300, 24)
+        emailField.placeholder = "Email"
+        emailField.font = RobotoFont.regularWithSize(20)
+        emailField.textColor = MaterialColor.black
+        emailField.titleLabel = UILabel()
+        emailField.titleLabel!.font = RobotoFont.mediumWithSize(12)
+        emailField.titleLabelNormalColor = MaterialColor.grey.lighten2
+        emailField.titleLabelHighlightedColor = MaterialColor.blue.accent3
+        emailField.clearButtonMode = .WhileEditing
+        //		emailField.detailLabel = UILabel()
+        //		emailField.detailLabel!.text = "Email is incorrect."
+        //		emailField.detailLabel!.font = RobotoFont.mediumWithSize(12)
+        //		emailField.detailLabelHighlightedColor = MaterialColor.red.accent3
+        
+        emailField.validationBlock = ({(text:String) -> Bool in
+            let emailRegex = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}"
+            
+            let emailTest = NSPredicate(format:"SELF MATCHES %@" , emailRegex)
+            
+            let isValid = emailTest.evaluateWithObject(text)
+            return isValid;
+            
+        })
+        view.addSubview(emailField)
+    }
+    
+    /**
+     :name:	textFieldShouldReturn
+     :description: This is called when the user presses the Return
+     key on the keyboard.
+     */
+    func textFieldShouldReturn(textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        if textField == emailField {
+            //			(textField as! TextField).detailLabelHidden = false
+            emailField.validate("Invalid Email Address")
+        }
+        return false
+    }
+    
 }

--- a/Sources/TextField.swift
+++ b/Sources/TextField.swift
@@ -21,346 +21,379 @@ import UIKit
 public protocol TextFieldDelegate : UITextFieldDelegate {}
 
 public class TextField : UITextField {
-	/**
-	:name:	bottomBorderLayer
-	*/
-	public private(set) lazy var bottomBorderLayer: CAShapeLayer = CAShapeLayer()
-	
-	/**
-	:name:	backgroundColor
-	*/
-	public override var backgroundColor: UIColor? {
-		didSet {
-			layer.backgroundColor = backgroundColor?.CGColor
-		}
-	}
-	
-	/**
-	:name:	x
-	*/
-	public var x: CGFloat {
-		get {
-			return layer.frame.origin.x
-		}
-		set(value) {
-			layer.frame.origin.x = value
-		}
-	}
-	
-	/**
-	:name:	y
-	*/
-	public var y: CGFloat {
-		get {
-			return layer.frame.origin.y
-		}
-		set(value) {
-			layer.frame.origin.y = value
-		}
-	}
-	
-	/**
-	:name:	width
-	*/
-	public var width: CGFloat {
-		get {
-			return layer.frame.size.width
-		}
-		set(value) {
-			layer.frame.size.width = value
-		}
-	}
-	
-	/**
-	:name:	height
-	*/
-	public var height: CGFloat {
-		get {
-			return layer.frame.size.height
-		}
-		set(value) {
-			layer.frame.size.height = value
-		}
-	}
-	
-	/**
-	:name:	borderWidth
-	*/
-	public var borderWidth: MaterialBorder {
-		didSet {
-			layer.borderWidth = MaterialBorderToValue(borderWidth)
-		}
-	}
-	
-	/**
-	:name:	borderColor
-	*/
-	public var borderColor: UIColor? {
-		didSet {
-			layer.borderColor = borderColor?.CGColor
-		}
-	}
-	
-	/**
-	:name:	position
-	*/
-	public var position: CGPoint {
-		get {
-			return layer.position
-		}
-		set(value) {
-			layer.position = value
-		}
-	}
-	
-	/**
-	:name:	zPosition
-	*/
-	public var zPosition: CGFloat {
-		get {
-			return layer.zPosition
-		}
-		set(value) {
-			layer.zPosition = value
-		}
-	}
-	
-	/**
-	:name:	titleLabelNormalColor
-	*/
-	public var titleLabelNormalColor: UIColor? {
-		didSet {
-			titleLabel?.textColor = titleLabelNormalColor
-			bottomBorderLayer.backgroundColor = titleLabelNormalColor?.CGColor
-		}
-	}
-	
-	/**
-	:name:	titleLabelHighlightedColor
-	*/
-	public var titleLabelHighlightedColor: UIColor?
-	
-	/**
-	:name:	detailLabelHighlightedColor
-	*/
-	public var detailLabelHighlightedColor: UIColor?
-	
-	/**
-	:name:	titleLabel
-	*/
-	public var titleLabel: UILabel? {
-		didSet {
-			prepareTitleLabel()
-		}
-	}
-	
-	/**
-	:name:	detailLabel
-	*/
-	public var detailLabel: UILabel? {
-		didSet {
-			prepareDetailLabel()
-		}
-	}
-	
-	/**
-	:name:	detailLabelHidden
-	*/
-	public var detailLabelHidden: Bool = false {
-		didSet {
-			if detailLabelHidden {
-				bottomBorderLayer.backgroundColor = editing ? titleLabelHighlightedColor?.CGColor : titleLabelNormalColor?.CGColor
-				hideDetailLabel()
-			} else {
-				detailLabel?.textColor = detailLabelHighlightedColor
-				bottomBorderLayer.backgroundColor = detailLabelHighlightedColor?.CGColor
-				showDetailLabel()
-			}
-		}
-	}
-	
-	/**
-	:name:	init
-	*/
-	public required init?(coder aDecoder: NSCoder) {
-		borderWidth = .None
-		super.init(coder: aDecoder)
-		prepareView()
-	}
-	
-	/**
-	:name:	init
-	*/
-	public override init(frame: CGRect) {
-		borderWidth = .None
-		super.init(frame: frame)
-		prepareView()
-	}
-	
-	/**
-	:name:	init
-	*/
-	public convenience init() {
-		self.init(frame: CGRectNull)
-	}
-	
-	/**
-	:name:	layoutSublayersOfLayer
-	*/
-	public override func layoutSublayersOfLayer(layer: CALayer) {
-		super.layoutSublayersOfLayer(layer)
-		if self.layer == layer {
-			bottomBorderLayer.frame = CGRectMake(0, bounds.height + 8, bounds.width, 1)
-		}
-	}
-	
-	/**
-	:name:	prepareView
-	*/
-	public func prepareView() {
-		clipsToBounds = false
-		prepareBottomBorderLayer()
-	}
-	
-	/**
-	:name:	textFieldDidBegin
-	*/
-	internal func textFieldDidBegin(textField: TextField) {
-		titleLabel?.text = placeholder
-		if 0 == text?.utf16.count {
-			titleLabel?.textColor = titleLabelNormalColor
-			bottomBorderLayer.backgroundColor = titleLabelNormalColor?.CGColor
-			detailLabelHidden = true
-		} else {
-			titleLabel?.textColor = titleLabelHighlightedColor
-			bottomBorderLayer.backgroundColor = detailLabelHidden ? titleLabelHighlightedColor?.CGColor : detailLabelHighlightedColor?.CGColor
-		}
-	}
-	
-	/**
-	:name:	textFieldDidChange
-	*/
-	internal func textFieldDidChange(textField: TextField) {
-		if 0 < text?.utf16.count {
-			showTitleLabel()
-			titleLabel?.textColor = titleLabelHighlightedColor
-			bottomBorderLayer.backgroundColor = detailLabelHidden ? titleLabelHighlightedColor?.CGColor : detailLabelHighlightedColor?.CGColor
-		} else if 0 == text?.utf16.count {
-			hideTitleLabel()
-			detailLabelHidden = true
-		}
-	}
-	
-	/**
-	:name:	textFieldDidEnd
-	*/
-	internal func textFieldDidEnd(textField: TextField) {
-		if 0 < text?.utf16.count {
-			showTitleLabel()
-		} else if 0 == text?.utf16.count {
-			hideTitleLabel()
-		}
-		titleLabel?.textColor = titleLabelNormalColor
-		bottomBorderLayer.backgroundColor = detailLabelHidden ? titleLabelNormalColor?.CGColor : detailLabelHighlightedColor?.CGColor
-	}
-	
-	/**
-	:name:	prepareTitleLabel
-	*/
-	private func prepareTitleLabel() {
-		if let v: UILabel = titleLabel {
-			MaterialAnimation.animationDisabled {
-				v.hidden = true
-				v.alpha = 0
-			}
-			titleLabel?.text = placeholder
-			let h: CGFloat = v.font.pointSize
-			v.frame = CGRectMake(0, -h, bounds.width, h)
-			addSubview(v)
-			addTarget(self, action: "textFieldDidBegin:", forControlEvents: .EditingDidBegin)
-			addTarget(self, action: "textFieldDidChange:", forControlEvents: .EditingChanged)
-			addTarget(self, action: "textFieldDidEnd:", forControlEvents: .EditingDidEnd)
-		}
-	}
-	
-	/**
-	:name:	prepareDetailLabel
-	*/
-	private func prepareDetailLabel() {
-		if let v: UILabel = detailLabel {
-			MaterialAnimation.animationDisabled {
-				v.hidden = true
-				v.alpha = 0
-			}
-			let h: CGFloat = v.font.pointSize
-			v.frame = CGRectMake(0, h + 12, bounds.width, h)
-			addSubview(v)
-			addTarget(self, action: "textFieldDidBegin:", forControlEvents: .EditingDidBegin)
-			addTarget(self, action: "textFieldDidChange:", forControlEvents: .EditingChanged)
-			addTarget(self, action: "textFieldDidEnd:", forControlEvents: .EditingDidEnd)
-		}
-	}
-	
-	/**
-	:name:	prepareBottomBorderLayer
-	*/
-	private func prepareBottomBorderLayer() {
-		layer.addSublayer(bottomBorderLayer)
-	}
-	
-	/**
-	:name:	showTitleLabel
-	*/
-	private func showTitleLabel() {
-		if let v: UILabel = titleLabel {
-			v.frame.size.height = v.font.pointSize
-			v.hidden = false
-			UIView.animateWithDuration(0.25, animations: {
-				v.alpha = 1
-				v.frame.origin.y = -v.frame.height - 4
-			})
-		}
-	}
-	
-	/**
-	:name:	hideTitleLabel
-	*/
-	private func hideTitleLabel() {
-		if let v: UILabel = titleLabel {
-			UIView.animateWithDuration(0.25, animations: {
-				v.alpha = 0
-				v.frame.origin.y = -v.frame.height
-			}) { _ in
-				v.hidden = true
-			}
-		}
-	}
-	
-	/**
-	:name:	showDetailLabel
-	*/
-	private func showDetailLabel() {
-		if let v: UILabel = detailLabel {
-			v.frame.size.height = v.font.pointSize
-			v.hidden = false
-			UIView.animateWithDuration(0.25, animations: {
-				v.alpha = 1
-				v.frame.origin.y = v.frame.height + 28
-			})
-		}
-	}
-	
-	/**
-	:name:	hideDetailLabel
-	*/
-	private func hideDetailLabel() {
-		if let v: UILabel = detailLabel {
-			UIView.animateWithDuration(0.25, animations: {
-				v.alpha = 0
-				v.frame.origin.y = v.frame.height + 20
-			}) { _ in
-				v.hidden = true
-			}
-		}
-	}
+    
+    public typealias MKTextFieldValidationBlock = ((text:String)-> Bool)!
+    
+    /**
+     :name:	bottomBorderLayer
+     */
+    public private(set) lazy var bottomBorderLayer: CAShapeLayer = CAShapeLayer()
+    
+    public var validationBlock : MKTextFieldValidationBlock?
+    
+    public private(set) var hasError : Bool! = false
+    
+    /**
+     :name:	backgroundColor
+     */
+    public override var backgroundColor: UIColor? {
+        didSet {
+            layer.backgroundColor = backgroundColor?.CGColor
+        }
+    }
+    
+    /**
+     :name:	x
+     */
+    public var x: CGFloat {
+        get {
+            return layer.frame.origin.x
+        }
+        set(value) {
+            layer.frame.origin.x = value
+        }
+    }
+    
+    /**
+     :name:	y
+     */
+    public var y: CGFloat {
+        get {
+            return layer.frame.origin.y
+        }
+        set(value) {
+            layer.frame.origin.y = value
+        }
+    }
+    
+    /**
+     :name:	width
+     */
+    public var width: CGFloat {
+        get {
+            return layer.frame.size.width
+        }
+        set(value) {
+            layer.frame.size.width = value
+        }
+    }
+    
+    /**
+     :name:	height
+     */
+    public var height: CGFloat {
+        get {
+            return layer.frame.size.height
+        }
+        set(value) {
+            layer.frame.size.height = value
+        }
+    }
+    
+    /**
+     :name:	borderWidth
+     */
+    public var borderWidth: MaterialBorder {
+        didSet {
+            layer.borderWidth = MaterialBorderToValue(borderWidth)
+        }
+    }
+    
+    /**
+     :name:	borderColor
+     */
+    public var borderColor: UIColor? {
+        didSet {
+            layer.borderColor = borderColor?.CGColor
+        }
+    }
+    
+    /**
+     :name:	position
+     */
+    public var position: CGPoint {
+        get {
+            return layer.position
+        }
+        set(value) {
+            layer.position = value
+        }
+    }
+    
+    /**
+     :name:	zPosition
+     */
+    public var zPosition: CGFloat {
+        get {
+            return layer.zPosition
+        }
+        set(value) {
+            layer.zPosition = value
+        }
+    }
+    
+    /**
+     :name:	titleLabelNormalColor
+     */
+    public var titleLabelNormalColor: UIColor? {
+        didSet {
+            titleLabel?.textColor = titleLabelNormalColor
+            bottomBorderLayer.backgroundColor = titleLabelNormalColor?.CGColor
+        }
+    }
+    
+    /**
+     :name:	titleLabelHighlightedColor
+     */
+    public var titleLabelHighlightedColor: UIColor?
+    
+    /**
+     :name:	detailLabelHighlightedColor
+     */
+    public var detailLabelHighlightedColor: UIColor? = MaterialColor.red.accent3
+    
+    /**
+     :name:	titleLabel
+     */
+    public var titleLabel: UILabel? {
+        didSet {
+            prepareTitleLabel()
+        }
+    }
+    
+    /**
+     :name:	detailLabel
+     */
+    public var detailLabel: UILabel? {
+        didSet {
+            prepareDetailLabel()
+        }
+    }
+    
+    /**
+     :name:	detailLabelHidden
+     */
+    public var detailLabelHidden: Bool = false {
+        didSet {
+            if detailLabelHidden {
+                bottomBorderLayer.backgroundColor = editing ? titleLabelHighlightedColor?.CGColor : titleLabelNormalColor?.CGColor
+                hideDetailLabel()
+            } else {
+                detailLabel?.textColor = detailLabelHighlightedColor
+                bottomBorderLayer.backgroundColor = detailLabelHighlightedColor?.CGColor
+                showDetailLabel()
+            }
+        }
+    }
+    
+    /**
+     :name:	init
+     */
+    public required init?(coder aDecoder: NSCoder) {
+        borderWidth = .None
+        super.init(coder: aDecoder)
+        prepareView()
+    }
+    
+    /**
+     :name:	init
+     */
+    public override init(frame: CGRect) {
+        borderWidth = .None
+        super.init(frame: frame)
+        prepareView()
+    }
+    
+    /**
+     :name:	init
+     */
+    public convenience init() {
+        self.init(frame: CGRectNull)
+    }
+    
+    /**
+     :name:	layoutSublayersOfLayer
+     */
+    public override func layoutSublayersOfLayer(layer: CALayer) {
+        super.layoutSublayersOfLayer(layer)
+        if self.layer == layer {
+            bottomBorderLayer.frame = CGRectMake(0, bounds.height + 8, bounds.width, 1)
+        }
+    }
+    
+    /**
+     :name:	prepareView
+     */
+    public func prepareView() {
+        clipsToBounds = false
+        prepareBottomBorderLayer()
+    }
+    
+    /**
+     :name:	textFieldDidBegin
+     */
+    internal func textFieldDidBegin(textField: TextField) {
+        titleLabel?.text = placeholder
+        if 0 == text?.utf16.count {
+            titleLabel?.textColor = titleLabelNormalColor
+            bottomBorderLayer.backgroundColor = titleLabelNormalColor?.CGColor
+            detailLabelHidden = true
+        } else {
+            titleLabel?.textColor = titleLabelHighlightedColor
+            bottomBorderLayer.backgroundColor = detailLabelHidden ? titleLabelHighlightedColor?.CGColor : detailLabelHighlightedColor?.CGColor
+        }
+    }
+    
+    /**
+     :name:	textFieldDidChange
+     */
+    internal func textFieldDidChange(textField: TextField) {
+        if 0 < text?.utf16.count {
+            showTitleLabel()
+            titleLabel?.textColor = titleLabelHighlightedColor
+            bottomBorderLayer.backgroundColor = detailLabelHidden ? titleLabelHighlightedColor?.CGColor : detailLabelHighlightedColor?.CGColor
+        } else if 0 == text?.utf16.count {
+            hideTitleLabel()
+            detailLabelHidden = true
+        }
+    }
+    
+    /**
+     :name:	textFieldDidEnd
+     */
+    internal func textFieldDidEnd(textField: TextField) {
+        if 0 < text?.utf16.count {
+            showTitleLabel()
+        } else if 0 == text?.utf16.count {
+            hideTitleLabel()
+        }
+        titleLabel?.textColor = titleLabelNormalColor
+        bottomBorderLayer.backgroundColor = detailLabelHidden ? titleLabelNormalColor?.CGColor : detailLabelHighlightedColor?.CGColor
+    }
+    
+    /**
+     :name:	prepareTitleLabel
+     */
+    private func prepareTitleLabel() {
+        if let v: UILabel = titleLabel {
+            MaterialAnimation.animationDisabled {
+                v.hidden = true
+                v.alpha = 0
+            }
+            titleLabel?.text = placeholder
+            let h: CGFloat = v.font.pointSize
+            v.frame = CGRectMake(0, -h, bounds.width, h)
+            addSubview(v)
+            addTarget(self, action: "textFieldDidBegin:", forControlEvents: .EditingDidBegin)
+            addTarget(self, action: "textFieldDidChange:", forControlEvents: .EditingChanged)
+            addTarget(self, action: "textFieldDidEnd:", forControlEvents: .EditingDidEnd)
+        }
+    }
+    
+    /**
+     :name:	prepareDetailLabel
+     */
+    private func prepareDetailLabel() {
+        if let v: UILabel = detailLabel {
+            MaterialAnimation.animationDisabled {
+                v.hidden = true
+                v.alpha = 0
+            }
+            let h: CGFloat = v.font.pointSize
+            v.frame = CGRectMake(0, h + 12, bounds.width, h)
+            addSubview(v)
+            addTarget(self, action: "textFieldDidBegin:", forControlEvents: .EditingDidBegin)
+            addTarget(self, action: "textFieldDidChange:", forControlEvents: .EditingChanged)
+            addTarget(self, action: "textFieldDidEnd:", forControlEvents: .EditingDidEnd)
+        }
+    }
+    
+    /**
+     :name:	prepareBottomBorderLayer
+     */
+    private func prepareBottomBorderLayer() {
+        layer.addSublayer(bottomBorderLayer)
+    }
+    
+    /**
+     :name:	showTitleLabel
+     */
+    private func showTitleLabel() {
+        if let v: UILabel = titleLabel {
+            v.frame.size.height = v.font.pointSize
+            v.hidden = false
+            UIView.animateWithDuration(0.25, animations: {
+                v.alpha = 1
+                v.frame.origin.y = -v.frame.height - 4
+            })
+        }
+    }
+    
+    /**
+     :name:	hideTitleLabel
+     */
+    private func hideTitleLabel() {
+        if let v: UILabel = titleLabel {
+            UIView.animateWithDuration(0.25, animations: {
+                v.alpha = 0
+                v.frame.origin.y = -v.frame.height
+                }) { _ in
+                    v.hidden = true
+            }
+        }
+    }
+    
+    /**
+     :name:	showDetailLabel
+     */
+    private func showDetailLabel() {
+        if let v: UILabel = detailLabel {
+            v.frame.size.height = v.font.pointSize
+            v.hidden = false
+            UIView.animateWithDuration(0.25, animations: {
+                v.alpha = 1
+                v.frame.origin.y = v.frame.height + 28
+            })
+        }
+    }
+    
+    /**
+     :name:	hideDetailLabel
+     */
+    private func hideDetailLabel() {
+        if let v: UILabel = detailLabel {
+            UIView.animateWithDuration(0.25, animations: {
+                v.alpha = 0
+                v.frame.origin.y = v.frame.height + 20
+                }) { _ in
+                    v.hidden = true
+            }
+        }
+    }
+    
+    private func performValidation(isValid:Bool, message:String){
+        if !isValid {
+            self.hasError = true
+            //if detail lable is null, we initialize with default
+            if detailLabel == nil {
+                detailLabel = UILabel()
+                detailLabel!.font = RobotoFont.mediumWithSize(12)
+            }
+            self.detailLabel!.text = message
+            detailLabelHidden = false
+        } else {
+            self.hasError = false
+            detailLabelHidden = true
+        }
+    }
+    
+    public func validate(errorMessage: String) -> Bool{
+        if let _ = validationBlock {
+            
+            let isValid = self.validationBlock!(text: (self.text == nil ? "" : self.text!))
+            performValidation(isValid,message: errorMessage)
+            return isValid
+        }
+        return true
+    }
 }


### PR DESCRIPTION
Now the user can set the validation block and validate textInput with blocks with simply calling validate(errorMessage) on the textField. No need to set up the detailLabel (which now serves as an error label)